### PR TITLE
Some fixes to layout to make it accessible via mobile

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -50,6 +50,8 @@ dl {
   flex-direction: column;
   box-sizing: border-box;
   padding: 70px 0 1em;
+  width: 100%;
+  min-width: 360px;
 }
 
 .page--header {
@@ -65,12 +67,20 @@ dl {
 .page--aside {
   box-sizing: border-box;
   padding: 0 1em;
+  order: 1;
+  margin-top: 1em;
+  border-top: 1px solid #eee;
 }
 
 .page--container {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   flex-grow: 1;
+}
+
+.page--logo {
+  float: right;
+  padding: 1em 0;
 }
 
 .page--content {
@@ -96,13 +106,6 @@ dl {
   }
 }
 
-@media screen and (min-width: 460px) and (max-width: 699px) {
-  .page--logo {
-    float: right;
-    padding: 1em 0;
-  }
-}
-
 @media screen and (min-width: 700px) {
   .page {
     flex-direction: column;
@@ -116,6 +119,12 @@ dl {
   .page--aside {
     flex-basis: 250px;
     order: 1;
+    margin-top: 0;
+    border-top: none;
+  }
+
+  .page--logo {
+    float: none;
   }
 
   .page--container {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -51,7 +51,6 @@ dl {
   box-sizing: border-box;
   padding: 70px 0 1em;
   width: 100%;
-  min-width: 360px;
 }
 
 .page--header {

--- a/src/css/podcast.module.css
+++ b/src/css/podcast.module.css
@@ -1,20 +1,20 @@
-
 .title {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 256px;
+  height: 128px;
   background: url(/podcast_cover.png);
+  background-size: cover;
   color: #fff;
   text-align: center;
   margin-top: 0;
-  font-size: 50px;
+  font-size: 32px;
   font-weight: 200;
   line-height: 0;
 }
 
-.post {
+.post:not(:last-of-type) {
   border-bottom: 1px solid #eee;
   padding-bottom: 20px;
   margin-bottom: 20px;
@@ -40,6 +40,7 @@
 .header_date {
   font-weight: 200;
   color: #7b7b7b;
+  white-space: nowrap;
 }
 
 .footer {
@@ -50,4 +51,11 @@
 .footer ul {
   list-style: none;
   margin-left: 0;
+}
+
+@media screen and (min-width: 700px) {
+  .title {
+    height: 256px;
+    font-size: 50px;
+  }
 }


### PR DESCRIPTION
Хэй, привет. Столкнулся с тем, что на мобиле оч тяжело смотреть на страницу подкаста, не говоря уже о том, чтобы запустить аудио или выбрать нужное время. Вроде бы поправил, буду рад, если пригодится :pizza::pizza:

Ниже по-английски, чтобы сохранить серьёзность:

### Main
* Stretch page content to viewport width and set min width
* Move aside content to the bottom on mobile

### Podcast
* Make header smaller for mobile
* Don't show border under the last post since aside content just below it will have the same border

Preview: https://public-javfltagey.now.sh/