### PR TITLE
Делает порядок выпусков на странице /podcasts обратным

### DIFF
--- a/src/components/podcast.js
+++ b/src/components/podcast.js
@@ -60,7 +60,7 @@ export default props => {
         </a>
       </div>
       <div className={styles.posts}>
-        {edges.map(({node: {title, date, formatedDate}}, index) => {
+        {edges.reverse().map(({node: {title, date, formatedDate}}, index) => {
           return (
             <PostLink
               key={index}


### PR DESCRIPTION
Когда заходишь на /podcasts, хочется в первую очередь видеть свежие выпуски. 
Ишью такой нет, @lapanoid сказал сразу делать PR