### PR TITLE
Добавляет метку времени в url страницы с выпуском подкаста

### DIFF
--- a/src/components/podcast-page/index.js
+++ b/src/components/podcast-page/index.js
@@ -1,7 +1,7 @@
 'use strict'
 import React, {Component} from 'react'
 import styles from './style.module.css'
-import Link from 'gatsby-link'
+import Link, {navigateTo} from 'gatsby-link'
 import marked from 'marked'
 import {Box, Thread} from 'react-disqussion'
 import {timestampToSeconds} from '../../utils/time'
@@ -12,6 +12,8 @@ class PodcastPage extends Component {
   constructor(props) {
     super(props)
     this.handleTimeClick = this.handleTimeClick.bind(this)
+    this.handleTimeUpdate = this.handleTimeUpdate.bind(this)
+    this.initialTimeHash = `#t=${this.getInitialTime()}`
   }
 
   handleTimeClick(e) {
@@ -24,6 +26,16 @@ class PodcastPage extends Component {
 
   handleSpeedClick(speed) {
     this.audioEl.playbackRate = speed
+  }
+
+  handleTimeUpdate() {
+    const time = Math.trunc(this.audioEl.currentTime)
+    navigateTo(`${location.pathname}?time=${time}`)
+  }
+
+  getInitialTime() {
+    const rgexRes = location.search.match(/time=(\d+)/)
+    return rgexRes ? rgexRes[1] : 0
   }
 
   render() {
@@ -46,7 +58,8 @@ class PodcastPage extends Component {
             className={styles.player_audio}
             controls='controls'
             preload='metadata'
-            src={link}
+            src={link + this.initialTimeHash}
+            onTimeUpdate={this.handleTimeUpdate}
             ref={el => (this.audioEl = el)} />
           <div className={styles.player_controls}>
             {PLAYBACK_RATES.map(speed => (

--- a/src/components/podcast.js
+++ b/src/components/podcast.js
@@ -60,14 +60,14 @@ export default props => {
         </a>
       </div>
       <div className={styles.posts}>
-        {edges.map(({node: {title, date, formatedDate}}, index) => {
+        {edges.map(({node: {title, date, formatedDate, number}}, index) => {
           return (
             <PostLink
               key={index}
               title={title}
               date={date}
               formatedDate={formatedDate}
-              to={`/podcast/${index + 1}`} />
+              to={`/podcast/${number}`} />
           )
         })}
       </div>

--- a/src/pages/podcast.js
+++ b/src/pages/podcast.js
@@ -50,7 +50,7 @@ export default ({data: {allContentfulDrinkcast: {edges}}}) => (
 
 export const pageQuery = graphql`
   query MyQueryName {
-    allContentfulDrinkcast(limit: 1000, sort: {order: ASC, fields: [date]}) {
+    allContentfulDrinkcast(limit: 1000, sort: {order: DESC, fields: [date]}) {
       edges {
         node {
           title


### PR DESCRIPTION
При проигрывании аудио в url страницы добавляется текущее время в виде `?time=<время в секундах>`.

При загрузке страницы, время парсится из url'a и добавляется к ссылке на аудио.

Если вдруг что-то сделал не по канону, чур по голове не бить :)
Критикуйте, переделаю PR, если что.